### PR TITLE
Add pg service file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ ARG GIT_REPO=https://github.com/qwc-services/qwc-config-db.git
 
 ENV PGSERVICEFILE=/tmp/.pg_service.conf
 
+# copy connection service for migrations
+COPY pg_service_base.conf /tmp/.pg_service.conf
+
 COPY install-postgis.sh install-alembic-and-clone-qwc-config-db.sh /usr/local/bin/
 RUN  cd /usr/local/bin && \
      chmod +x install-postgis.sh install-alembic-and-clone-qwc-config-db.sh

--- a/install-alembic-and-clone-qwc-config-db.sh
+++ b/install-alembic-and-clone-qwc-config-db.sh
@@ -15,11 +15,13 @@ QWC_CONFIG_DB_GIT_REPO="$1"
 QWC_CONFIG_DB_DEST="$2"
 
 apt-get install -y ca-certificates tmux screen curl less \
-                   git python3-pip python3-psycopg2 gdal-bin
+                   git python3-pip python3-psycopg2 python3-venv libpq-dev gdal-bin
 
 # get qwc-config-db for migrations
 cd /tmp/ && git clone $QWC_CONFIG_DB_GIT_REPO qwc-config-db
 cd /tmp/qwc-config-db/ && git pull
-pip3 install --upgrade pip
-pip3 install --no-cache-dir -r /tmp/qwc-config-db/requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install --no-cache-dir -r /tmp/qwc-config-db/requirements.txt
 

--- a/pg_service_base.conf
+++ b/pg_service_base.conf
@@ -1,0 +1,7 @@
+[qwc_configdb]
+host=
+port=5432
+dbname=qwc_demo
+user=qwc_admin
+password=qwc_admin
+sslmode=disable

--- a/run-migrations.sh
+++ b/run-migrations.sh
@@ -3,4 +3,5 @@ set -e
 
 # run migrations from qwc-config-db
 cd /tmp/qwc-config-db/
+source .venv/bin/activate
 PGSERVICE=qwc_configdb alembic upgrade ${ALEMBIC_VERSION:-head}


### PR DESCRIPTION
Hi,

I create this PR to add PG service file in `qwc-base-db` image as it is done in `qwc-demo-db`.  It allows service to connect to local database in container and run migrations.

I don't know if we need to uncomment these lines to set locales. (I had to do this to use my own image)

```Dockerfile
RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
ENV LANG en_US.utf8
```

I also need to create and use virtual env to install requirements.

Thanks