### PR TITLE
Set passwords in env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ ARG POSTGIS_VERSION=3
 ENV PGDATA=/var/lib/postgresql/docker
 ENV POSTGRES_PASSWORD=
 
+# ENV for qwc-services database roles passwords
+ENV QGIS_SERVER_PASSWORD=qgis_server
+ENV QWC_ADMIN_PASSWORD=qwc_admin
+ENV QWC_SERVICE_PASSWORD=qwc_service
+ENV QWC_SERVICE_WRITE_PASSWORD=qwc_service_write
 
 # Install postgis
 RUN \

--- a/Dockerfile.migrate
+++ b/Dockerfile.migrate
@@ -6,7 +6,6 @@ ENV ALEMBIC_VERSION=head
 
 RUN apk add --no-cache --update postgresql-client py3-alembic py3-psycopg2
 
-COPY pg_service.conf /tmp/pg_service.conf
 COPY alembic.ini /tmp/alembic.ini
 COPY alembic /tmp/alembic
 COPY run-migrations.sh /tmp/run-migrations.sh

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ These images are designed to be configured in a `docker-compose.yml` as follows 
 Note:
 
 * **You need to set a non-empty `POSTGRES_PASSWORD` ENV variable**.
+* You can set passwords for roles in `qwc_services` database with ENV variables: `QGIS_SERVER_PASSWORD`, `QWC_ADMIN_PASSWORD`, `QWC_SERVICE_PASSWORD`, `QWC_SERVICE_WRITE_PASSWORD`. These variables have default values (`qgis_server`, `qwc_admin`, `qwc_service`, `qwc_service_write`).
 * For persistent storage, mount folder volume to `/var/lib/postgresql/docker`.
 * The `sourcepole/qwc-base-db` images are versioned according to the Postgres major version (i.e. 13, 14, 15, ...).
 * The `sourcepole/qwc-base-db-migrate` images are versioned by date (`vYYYY.MM.DD`)
@@ -46,6 +47,15 @@ The `qwc-config-db-migrate` image will run `qwc-postgis` is up, and will apply a
 
 To keep the Config DB up to date, it is sufficient to update the `qwc-base-db-migrate` image version to the latest available version.
 
+Configure the `qwc-config-db-migrate` image mounting the `pg_service.conf` containing the connection information to your database:
+
+```yml
+  qwc-config-db-migrate:
+    image: sourcepole/qwc-base-db-migrate:<version>
+  volumes:
+    ./pg_service.conf:/tmp/pg_service.conf:ro
+```
+
 Migrations will be applied automatically, if necessary, whenever the Docker application is started.
 
 To upgrade to a migration different than `head`, set the `ALEMBIC_VERSION` ENV variable.
@@ -54,7 +64,7 @@ To upgrade to a migration different than `head`, set the `ALEMBIC_VERSION` ENV v
 
 You can use an external DB instead of the `qwc-base-db` dockerized DB.
 
-To set up the external DB, run the SQL commands in `setup-roles-and-db.sh` on your external DB.
+To set up the external DB, set passwords for roles with ENV variables (`QGIS_SERVER_PASSWORD`, `QWC_ADMIN_PASSWORD`, `QWC_SERVICE_PASSWORD`, `QWC_SERVICE_WRITE_PASSWORD`) and run the SQL commands in `setup-roles-and-db.sh` on your external DB.
 
 To apply the migrations, both as part as the initial setup and subsequently to keep the Config DB up-to-date:
 

--- a/setup-roles-and-db.sh
+++ b/setup-roles-and-db.sh
@@ -2,10 +2,10 @@
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
-  CREATE ROLE qgis_server LOGIN PASSWORD 'qgis_server';
-  CREATE ROLE qwc_admin LOGIN PASSWORD 'qwc_admin';
-  CREATE ROLE qwc_service LOGIN PASSWORD 'qwc_service';
-  CREATE ROLE qwc_service_write LOGIN PASSWORD 'qwc_service_write';
+  CREATE ROLE qgis_server LOGIN PASSWORD '$QGIS_SERVER_PASSWORD';
+  CREATE ROLE qwc_admin LOGIN PASSWORD '$QWC_ADMIN_PASSWORD';
+  CREATE ROLE qwc_service LOGIN PASSWORD '$QWC_SERVICE_PASSWORD';
+  CREATE ROLE qwc_service_write LOGIN PASSWORD '$QWC_SERVICE_WRITE_PASSWORD';
 
   CREATE DATABASE qwc_services;
   COMMENT ON DATABASE qwc_services IS 'DB for qwc-services';


### PR DESCRIPTION
Hello,

This PR allows to set passwords for roles created in `qwc_services` database.

In the migration docker image, it is not needed to copy `pg_service.conf` anymore as `qwc_admin` password may have changed. We need to mount `pg_service.conf` file with container.

Thanks